### PR TITLE
@ric/related products route controller

### DIFF
--- a/server/__tests__/index.js
+++ b/server/__tests__/index.js
@@ -3,6 +3,7 @@
 const app = require('../index');
 const productTests = require('./products.test');
 const qaTests = require('./qa.test');
+const relatedTests = require('./related.test');
 
 let server;
 
@@ -17,4 +18,5 @@ afterAll((done) => {
 describe('Server Routes', () => {
   productTests(app);
   qaTests(app);
+  relatedTests(app);
 });

--- a/server/__tests__/related.test.js
+++ b/server/__tests__/related.test.js
@@ -1,0 +1,14 @@
+/* eslint-env jest */
+
+const request = require('supertest');
+
+module.exports = (app) => {
+  describe('Related Products API', () => {
+    it('should recieve array on GET /products/:product_id/related', async () => {
+      const agent = request(app);
+      const relatedResponse = await agent.get('/products/40349/related').expect(200);
+      const relatedProducts = JSON.parse(relatedResponse.text);
+      expect(relatedProducts.length).toBeGreaterThan(0);
+    });
+  });
+};

--- a/server/controllers/related.js
+++ b/server/controllers/related.js
@@ -1,0 +1,15 @@
+const axios = require('axios');
+
+module.exports.related = {
+  getAll: (req, res) => {
+    axios({
+      url: `/products/${req.params.product_id}/related`,
+      method: 'get',
+      baseURL: process.env.SERVER,
+      headers: { Authorization: process.env.API_TOKEN },
+      params: req.params,
+    })
+      .then((data) => res.status(200).send(data.data))
+      .catch((err) => res.status(500).send(err));
+  },
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,7 +1,9 @@
 const questionsAnswers = require('./questionsAnswers');
 const products = require('./products');
+const related = require('./related');
 
 module.exports = (app) => {
   questionsAnswers(app);
   products(app);
+  related(app);
 };

--- a/server/routes/related.js
+++ b/server/routes/related.js
@@ -1,0 +1,5 @@
+const { related } = require('../controllers/related');
+
+module.exports = (app) => {
+  app.get('/products/:product_id/related', related.getAll);
+};


### PR DESCRIPTION
Added related.js file in the routes folder containing a GET request route to the related products enpoint

Added a getAll method to retrieve all related product_id's for a given product_id. This was added in the new related.js file in the controllers folder. 

added a test for this route in the new file related.test.js in the server/__tests__ folder. This test is passing and all previous tests still pass as well. 

imported as necessary in server/routes/index.js and server/__tests__/index.js